### PR TITLE
feat: add content_type parameter to role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Web::Request::Role::JSON - Make handling JSON easier in Web::Request
 
 # VERSION
 
-version 1.004
+version 1.005
 
 # SYNOPSIS
 
@@ -74,15 +74,27 @@ Per default, HTTP status is set to `400`, but you can pass any other
 status as a second argument. (Yes, there is no checking if you pass a
 valid status code or not. You're old enough to not do stupid things..)
 
+## PARAMETERS
+
+An optional `content_type` parameter can be added on role application. Modern
+browsers tend to like this better.
+
+    package MyRequest;
+    extends 'OX::Request';
+    with (
+        'Web::Request::Role::JSON' => { content_type => 'application/json; charset=utf-8' },
+    );
+
 # THANKS
 
 Thanks to
 
 - [validad.com](https://www.validad.com/) for supporting Open Source.
 
-# AUTHOR
+# AUTHORS
 
-Thomas Klausner <domm@cpan.org>
+- Thomas Klausner <domm@cpan.org>
+- Klaus Ita <koki@itascraft.com>
 
 # COPYRIGHT AND LICENSE
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'Web::Request';
 requires 'JSON::MaybeXS';
+requires 'MooseX::Role::Parameterized';
 
 on 'test' => sub {
     requires 'Test::Most';

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,6 @@
 name    = Web-Request-Role-JSON
 author  = Thomas Klausner <domm@cpan.org>
+author  = Klaus Ita <koki@itascraft.com>
 license = Perl_5
 copyright_holder = Thomas Klausner
 copyright_year   = 2017

--- a/lib/Web/Request/Role/JSON.pm
+++ b/lib/Web/Request/Role/JSON.pm
@@ -2,71 +2,82 @@ package Web::Request::Role::JSON;
 
 # ABSTRACT: Make handling JSON easier in Web::Request
 
-our $VERSION = '1.004';
+our $VERSION = '1.005';
 
 use 5.010;
-use Moose::Role;
+use MooseX::Role::Parameterized;
 use JSON::MaybeXS;
 use Encode;
 
-sub json_payload {
-    my $self = shift;
+parameter 'content_type' => (
+    isa      => 'Str',
+    required => 0,
+    default  => 'application/json',
+);
 
-    return unless my $raw = $self->content;
+role {
+    my $p            = shift;
+    my $content_type = $p->content_type;
 
-    # Web::Request->content will decode content based on
-    # $req->encoding, which is utf8 for JSON. So $content has UTF8 flag
-    # on, which means we have to tell JSON::MaybeXS to turn
-    # utf8-handling OFF
+    method json_payload => sub {
+        my $self = shift;
 
-    return JSON::MaybeXS->new(utf8=>0)->decode($raw);
+        return unless my $raw = $self->content;
 
-    # Alternatives:
-    # - reencode the content (stupid because double the work)
-    #   decode_json(encode_utf8($self->content))
-    # - set $self->encoding(undef), and set it back after decoding
-}
+        # Web::Request->content will decode content based on
+        # $req->encoding, which is utf8 for JSON. So $content has UTF8 flag
+        # on, which means we have to tell JSON::MaybeXS to turn
+        # utf8-handling OFF
 
-sub json_response {
-    my ( $self, $data, $header_ref, $status ) = @_;
+        return JSON::MaybeXS->new( utf8 => 0 )->decode($raw);
 
-    $status ||= 200;
-    my $headers;
-    if ($header_ref) {
-        if (ref($header_ref) eq 'ARRAY') {
-            $headers = HTTP::Headers->new(@$header_ref);
+        # Alternatives:
+        # - reencode the content (stupid because double the work)
+        #   decode_json(encode_utf8($self->content))
+        # - set $self->encoding(undef), and set it back after decoding
+    };
+
+    method json_response => sub {
+        my ( $self, $data, $header_ref, $status ) = @_;
+
+        $status ||= 200;
+        my $headers;
+        if ($header_ref) {
+            if ( ref($header_ref) eq 'ARRAY' ) {
+                $headers = HTTP::Headers->new(@$header_ref);
+            }
+            elsif ( ref($header_ref) eq 'HASH' ) {
+                $headers = HTTP::Headers->new(%$header_ref);
+            }
         }
-        elsif (ref($header_ref) eq 'HASH') {
-            $headers = HTTP::Headers->new(%$header_ref);
+        $headers ||= HTTP::Headers->new;
+        $headers->header( 'content-type' => $content_type );
+
+        return $self->new_response(
+            headers => $headers,
+            status  => $status,
+            content => decode_utf8( encode_json($data) ),
+        );
+    };
+
+    method json_error => sub {
+        my ( $self, $message, $status ) = @_;
+        $status ||= 400;
+        my $body;
+        if ( ref($message) ) {
+            $body = $message;
         }
-    }
-    $headers ||= HTTP::Headers->new;
-    $headers->header( 'content-type' => 'application/json' );
+        else {
+            $body = { status => 'error', message => "$message" };
+        }
 
-    return $self->new_response(
-        headers => $headers,
-        status  => $status,
-        content => decode_utf8( encode_json($data) ),
-    );
-}
-
-sub json_error {
-    my ( $self, $message, $status ) = @_;
-    $status ||= 400;
-    my $body;
-    if ( ref($message) ) {
-        $body = $message;
-    }
-    else {
-        $body = { status => 'error', message => "$message" };
-    }
-
-    return $self->new_response(
-        headers => [ content_type => 'application/json' ],
-        status  => $status,
-        content => decode_utf8( encode_json($body) ),
-    );
-}
+        return $self->new_response(
+            headers => [ content_type => $content_type ],
+            status  => $status,
+            content => decode_utf8( encode_json($body) ),
+        );
+    };
+};
 
 1;
 
@@ -137,6 +148,17 @@ converte to JSON.
 Per default, HTTP status is set to C<400>, but you can pass any other
 status as a second argument. (Yes, there is no checking if you pass a
 valid status code or not. You're old enough to not do stupid things..)
+
+=head2 PARAMETERS
+
+An optional C<content_type> parameter can be added on role application. Modern
+browsers tend to like this better.
+
+    package MyRequest;
+    extends 'OX::Request';
+    with (
+        'Web::Request::Role::JSON' => { content_type => 'application/json; charset=utf-8' },
+    );
 
 =head1 THANKS
 

--- a/lib/Web/Request/Role/JSON.pm
+++ b/lib/Web/Request/Role/JSON.pm
@@ -12,7 +12,7 @@ use Encode;
 parameter 'content_type' => (
     isa      => 'Str',
     required => 0,
-    default  => 'application/json',
+    default  => 'application/json; charset=utf-8',
 );
 
 role {
@@ -151,13 +151,14 @@ valid status code or not. You're old enough to not do stupid things..)
 
 =head2 PARAMETERS
 
-An optional C<content_type> parameter can be added on role application. Modern
-browsers tend to like this better.
+An optional C<content_type> parameter can be added on role application to
+restore previous behaviour. Browsers tend to like the 'charset=utf-8' better,
+but you might have your reasons. 
 
     package MyRequest;
     extends 'OX::Request';
     with (
-        'Web::Request::Role::JSON' => { content_type => 'application/json; charset=utf-8' },
+        'Web::Request::Role::JSON' => { content_type => 'application/json' },
     );
 
 =head1 THANKS

--- a/t/basic.t
+++ b/t/basic.t
@@ -143,7 +143,7 @@ test_psgi(
         subtest 'json_response plain' => sub {
             my $res = $cb->( GET "http://localhost/get/plain" );
             is( $res->code, 200, 'status' );
-            is( $res->content_type, 'application/json', 'content-type' );
+            is( $res->header('content-type'), 'application/json; charset=utf-8', 'content-type' );
             is( decode_utf8( $res->content ), '{"value":"plain"}',
                 'content' );
         };

--- a/t/parameters.t
+++ b/t/parameters.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+use Test::More;
+use HTTP::Request;
+use HTTP::Request::Common;
+use Plack::Test;
+use Plack::Builder;
+use Web::Request;
+use Encode;
+use JSON::MaybeXS qw(encode_json decode_json is_bool);
+use utf8;
+
+package Request;
+use Moose;
+extends "Web::Request";
+with(
+    'Web::Request::Role::JSON' => {
+        content_type => 'application/json; charset=utf-8'
+    }
+);
+
+sub default_encoding { return 'UTF-8' }
+
+1;
+
+package main;
+
+# The fake app we use for testing
+my $handler = builder {
+    sub {
+        my $env = shift;
+
+        #        my $req  = $req_class->name->new_from_env($env);
+        my $req  = Request->new_from_env($env);
+        my $path = $env->{PATH_INFO};
+
+        my $res;
+
+        # json_response
+        if ( $path eq '/get/utf8' ) {
+            $res = $req->json_response( { value => 'töst' } );
+        }
+
+        return $res->finalize;
+    };
+};
+
+# and finally the tests!
+test_psgi(
+    app    => $handler,
+    client => sub {
+        my $cb = shift;
+
+        subtest 'json_response plain' => sub {
+            my $res = $cb->( GET "http://localhost/get/utf8" );
+            is( $res->code, 200, 'status' );
+            is(
+                $res->header('content-type'),
+                'application/json; charset=utf-8',
+                'content-type'
+            );
+            is( decode_utf8( $res->content ), '{"value":"töst"}', 'content' );
+        };
+
+    }
+);
+
+done_testing;

--- a/t/parameters.t
+++ b/t/parameters.t
@@ -15,7 +15,7 @@ use Moose;
 extends "Web::Request";
 with(
     'Web::Request::Role::JSON' => {
-        content_type => 'application/json; charset=utf-8'
+        content_type => 'application/json'
     }
 );
 
@@ -56,7 +56,7 @@ test_psgi(
             is( $res->code, 200, 'status' );
             is(
                 $res->header('content-type'),
-                'application/json; charset=utf-8',
+                'application/json',
                 'content-type'
             );
             is( decode_utf8( $res->content ), '{"value":"töst"}', 'content' );


### PR DESCRIPTION
Adding the charset to the json response is more stable and explicit for
modern browsers to display the json payload correctly when it contains
non-ascii characters.

  with ('Web::Request::Role::JSON' => { content_type =>
  'application/json; utf-8' } );